### PR TITLE
Add tag support, keyboard shortcuts, and UI refinements to Clipboard

### DIFF
--- a/MacClipboard/ContentView.swift
+++ b/MacClipboard/ContentView.swift
@@ -39,7 +39,7 @@ struct ContentView: View {
                                 onCopy: showCopyFeedback)
                     .frame(minWidth: 400, minHeight: 400)
                     .navigationTitle("Clipboard History")
-                    .onChange(of: selectedTab) { newTab in
+                    .onChange(of: selectedTab) { newTab, _ in
                         updateSelectionForTab(newTab)
                     }
                     .toolbar {
@@ -182,3 +182,4 @@ struct ContentView: View {
     ContentView()
         .environmentObject(ClipboardManager())
 }
+

--- a/MacClipboard/Features/Clipboard/LandingLobby/Views/List/ClipboardGroupTabs.swift
+++ b/MacClipboard/Features/Clipboard/LandingLobby/Views/List/ClipboardGroupTabs.swift
@@ -50,7 +50,7 @@ private struct DefaultTabsView: View {
                     .foregroundColor(selectedTab == .all ? .white : .primary)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(FixedHeightButtonStyle())
             
             Button(action: { selectedTab = .favorites }) {
                 Label("Favorites", systemImage: "star.fill")
@@ -60,7 +60,7 @@ private struct DefaultTabsView: View {
                     .foregroundColor(selectedTab == .favorites ? .white : .primary)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(FixedHeightButtonStyle())
         }
         .background(Color.secondary.opacity(0.2))
         .cornerRadius(6)
@@ -71,6 +71,7 @@ private struct CustomGroupsTabsView: View {
     @ObservedObject var clipboardManager: ClipboardManager
     @Binding var selectedTab: Tab
     @State private var hoveredGroupId: UUID? = nil
+    @State private var hoveredDeleteButtonId: UUID? = nil
     
     var body: some View {
         HStack {
@@ -95,7 +96,7 @@ private struct CustomGroupsTabsView: View {
                             )
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(FixedHeightButtonStyle())
                     
                     if hoveredGroupId == group.id {
                         Button(action: {
@@ -105,16 +106,26 @@ private struct CustomGroupsTabsView: View {
                                 selectedTab = .all
                             }
                         }) {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundColor(.red)
-                                .padding(.horizontal, 4)
-                                .padding(.trailing, 4)
+                            ZStack {
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill((hoveredDeleteButtonId == group.id) ? Color.red.opacity(0.15) : Color.clear)
+                                    .frame(width: 28, height: 28)
+                                    .animation(.easeInOut(duration: 0.2), value: hoveredDeleteButtonId)
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.red)
+                            }
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(FixedHeightButtonStyle())
+                        .onHover { hovering in
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                hoveredDeleteButtonId = hovering ? group.id : nil
+                            }
+                        }
                         .transition(.scale.combined(with: .opacity))
                     }
                 }
                 .background(Color.secondary.opacity(0.2))
+                .frame(height: 28)
                 .cornerRadius(6)
                 .onHover { hovering in
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -190,6 +201,20 @@ private struct NewGroupSheet: View {
     }
 }
 
+private struct FixedHeightButtonStyle: ButtonStyle {
+    var height: CGFloat = 28
+    var cornerRadius: CGFloat = 6
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(height: height)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(Color.clear) // You can customize this
+            )
+    }
+}
+
 #Preview {
     struct PreviewWrapper: View {
         @StateObject private var clipboardManager = ClipboardManager()
@@ -218,4 +243,4 @@ private struct NewGroupSheet: View {
     }
     
     return PreviewWrapper()
-} 
+}

--- a/MacClipboard/Features/Clipboard/LandingLobby/Views/List/ClipboardGroupTabs.swift
+++ b/MacClipboard/Features/Clipboard/LandingLobby/Views/List/ClipboardGroupTabs.swift
@@ -75,28 +75,44 @@ private struct CustomGroupsTabsView: View {
     
     var body: some View {
         HStack {
-            ForEach(clipboardManager.customGroups) { group in
+            // Use enumerated to get index for keyboard shortcuts
+            ForEach(Array(clipboardManager.customGroups.enumerated()), id: \.element.id) { index, group in
                 HStack(spacing: 0) {
                     Button(action: { selectedTab = .custom(group) }) {
-                        Label(group.name, systemImage: "folder.fill")
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 5)
-                            .background(
-                                Group {
-                                    if case .custom(let selectedGroup) = selectedTab,
-                                       selectedGroup.id == group.id {
-                                        Color.accentColor
-                                    } else {
-                                        Color.clear
-                                    }
+                        HStack(spacing: 4) {
+                            Image(systemName: "folder.fill")
+                            Text(group.name)
+                            if index < 10 {
+                                Text("\u{2318}\(index < 9 ? String(index + 1) : "0")")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .padding(.leading, 2)
+                            }
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(
+                            Group {
+                                if case .custom(let selectedGroup) = selectedTab,
+                                   selectedGroup.id == group.id {
+                                    Color.accentColor
+                                } else {
+                                    Color.clear
                                 }
-                            )
-                            .foregroundColor(
-                                (selectedTab == .custom(group)) ? .white : .primary
-                            )
-                            .contentShape(Rectangle())
+                            }
+                        )
+                        .foregroundColor(
+                            (selectedTab == .custom(group)) ? .white : .primary
+                        )
+                        .contentShape(Rectangle())
                     }
                     .buttonStyle(FixedHeightButtonStyle())
+                    // Assign keyboard shortcuts for the first 10 groups:
+                    // ⌘1 through ⌘9 for indexes 0-8, and ⌘0 for index 9
+                    .keyboardShortcut(
+                        index < 9 ? KeyEquivalent(Character(UnicodeScalar("1".unicodeScalars.first!.value + UInt32(index))!)) : KeyEquivalent("0"),
+                        modifiers: [.command]
+                    )
                     
                     if hoveredGroupId == group.id {
                         Button(action: {
@@ -244,3 +260,4 @@ private struct FixedHeightButtonStyle: ButtonStyle {
     
     return PreviewWrapper()
 }
+

--- a/MacClipboard/Features/Clipboard/LandingLobby/Views/List/ClipboardItemRow.swift
+++ b/MacClipboard/Features/Clipboard/LandingLobby/Views/List/ClipboardItemRow.swift
@@ -14,121 +14,144 @@ struct ClipboardItemRow: View {
     @Environment(\.colorScheme) private var colorScheme
     
     var body: some View {
-        HStack {
-            // Content area with selection highlight
+        ZStack(alignment: .topTrailing) {
             HStack {
-                VStack(alignment: .leading) {
-                    switch item.content {
-                    case .text(let string):
-                        Text(string)
-                            .lineLimit(2)
-                            .foregroundColor(colorScheme == .dark ? .white : .primary)
-                    case .image(let data):
-                        if let nsImage = NSImage(data: data) {
-                            Image(nsImage: nsImage)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(height: 40)
-                                .onTapGesture {
-                                    showingPreview.toggle()
+                // Content area with selection highlight
+                HStack {
+                    VStack(alignment: .leading) {
+                        switch item.content {
+                        case .text(let string):
+                            Text(string)
+                                .lineLimit(2)
+                                .foregroundColor(colorScheme == .dark ? .white : .primary)
+                        case .image(let data):
+                            if let nsImage = NSImage(data: data) {
+                                Image(nsImage: nsImage)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(height: 40)
+                                    .onTapGesture {
+                                        showingPreview.toggle()
+                                    }
+                                    .popover(isPresented: $showingPreview, arrowEdge: .leading) {
+                                        ImagePreviewView(imageData: data)
+                                            .frame(width: 600, height: 400)
+                                    }
+                            }
+                        }
+                        
+                        Text(item.timestamp, style: .time)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        
+                        if !item.tag.isEmpty {
+                            HStack(spacing: 4) {
+                                ForEach(item.tag, id: \.self) { tag in
+                                    Text(tag)
+                                        .modifier(TagStyleModifier(color: color(for: tag)))
                                 }
-                                .popover(isPresented: $showingPreview, arrowEdge: .leading) {
-                                    ImagePreviewView(imageData: data)
-                                        .frame(width: 600, height: 400)
-                                }
+                            }
+                            .padding(.top, 2)
                         }
                     }
                     
-                    Text(item.timestamp, style: .time)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                    Spacer()
                 }
-                
-                Spacer()
-            }
-            .padding(.vertical, 4)
-            .background(isSelected ? Color.accentColor.opacity(colorScheme == .dark ? 0.3 : 0.2) : Color.clear)
-            .cornerRadius(6)
-            .contextMenu {
-                if !clipboardManager.customGroups.isEmpty {
-                    Menu("Add to Group") {
-                        ForEach(clipboardManager.customGroups) { group in
-                            let isInGroup = clipboardManager.isItemInGroup(item, group: group)
-                            Button(action: {
-                                if isInGroup {
-                                    clipboardManager.removeItemFromGroup(item, group: group)
-                                } else {
-                                    clipboardManager.addItemToGroup(item, group: group)
-                                }
-                            }) {
-                                Label(group.name, systemImage: "folder.fill")
-                                if isInGroup {
-                                    Image(systemName: "checkmark")
+                .padding(.vertical, 4)
+                .background(isSelected ? Color.accentColor.opacity(colorScheme == .dark ? 0.3 : 0.2) : Color.clear)
+                .cornerRadius(6)
+                .contextMenu {
+                    if !clipboardManager.customGroups.isEmpty {
+                        Menu("Add to Group") {
+                            ForEach(clipboardManager.customGroups) { group in
+                                let isInGroup = clipboardManager.isItemInGroup(item, group: group)
+                                Button(action: {
+                                    if isInGroup {
+                                        clipboardManager.removeItemFromGroup(item, group: group)
+                                    } else {
+                                        clipboardManager.addItemToGroup(item, group: group)
+                                    }
+                                }) {
+                                    Label(group.name, systemImage: "folder.fill")
+                                    if isInGroup {
+                                        Image(systemName: "checkmark")
+                                    }
                                 }
                             }
                         }
+                        
+                        Divider()
                     }
                     
-                    Divider()
+                    Button(action: {
+                        clipboardManager.toggleFavorite(item)
+                    }) {
+                        Label(item.isFavorite ? "Remove from Favorites" : "Add to Favorites",
+                              systemImage: item.isFavorite ? "star.slash" : "star")
+                    }
                 }
                 
-                Button(action: {
-                    clipboardManager.toggleFavorite(item)
-                }) {
-                    Label(item.isFavorite ? "Remove from Favorites" : "Add to Favorites", 
-                          systemImage: item.isFavorite ? "star.slash" : "star")
+                // Action buttons outside the selection highlight
+                HStack(spacing: 12) {
+                    Button(action: {
+                        clipboardManager.toggleFavorite(item)
+                    }) {
+                        Image(systemName: item.isFavorite ? "star.fill" : "star")
+                            .foregroundColor(isFavoriteHovered ? .yellow : (item.isFavorite ? .yellow : .secondary))
+                            .padding(4)
+                            .background(isFavoriteHovered ? Color.yellow.opacity(0.2) : Color.clear)
+                            .cornerRadius(4)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        isFavoriteHovered = hovering
+                    }
+                    
+                    Button(action: {
+                        clipboardManager.copyToClipboard(item)
+                        onCopy()
+                    }) {
+                        Image(systemName: "doc.on.doc")
+                            .foregroundColor(isCopyHovered ? .white : .blue)
+                            .padding(4)
+                            .background(isCopyHovered ? Color.blue : Color.clear)
+                            .cornerRadius(4)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        isCopyHovered = hovering
+                    }
+                    
+                    Button(action: {
+                        clipboardManager.deleteItem(item)
+                    }) {
+                        Image(systemName: "trash")
+                            .foregroundColor(isDeleteHovered ? .white : .red)
+                            .padding(4)
+                            .background(isDeleteHovered ? Color.red : Color.clear)
+                            .cornerRadius(4)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(isLatest)
+                    .opacity(isLatest ? 0.5 : 1.0)
+                    .onHover { hovering in
+                        isDeleteHovered = hovering && !isLatest
+                    }
                 }
+                .padding(.leading, 8)
             }
-            
-            // Action buttons outside the selection highlight
-            HStack(spacing: 12) {
-                Button(action: {
-                    clipboardManager.toggleFavorite(item)
-                }) {
-                    Image(systemName: item.isFavorite ? "star.fill" : "star")
-                        .foregroundColor(isFavoriteHovered ? .yellow : (item.isFavorite ? .yellow : .secondary))
-                        .padding(4)
-                        .background(isFavoriteHovered ? Color.yellow.opacity(0.2) : Color.clear)
-                        .cornerRadius(4)
-                }
-                .buttonStyle(.plain)
-                .onHover { hovering in
-                    isFavoriteHovered = hovering
-                }
-                
-                Button(action: {
-                    clipboardManager.copyToClipboard(item)
-                    onCopy()
-                }) {
-                    Image(systemName: "doc.on.doc")
-                        .foregroundColor(isCopyHovered ? .white : .blue)
-                        .padding(4)
-                        .background(isCopyHovered ? Color.blue : Color.clear)
-                        .cornerRadius(4)
-                }
-                .buttonStyle(.plain)
-                .onHover { hovering in
-                    isCopyHovered = hovering
-                }
-                
-                Button(action: {
-                    clipboardManager.deleteItem(item)
-                }) {
-                    Image(systemName: "trash")
-                        .foregroundColor(isDeleteHovered ? .white : .red)
-                        .padding(4)
-                        .background(isDeleteHovered ? Color.red : Color.clear)
-                        .cornerRadius(4)
-                }
-                .buttonStyle(.plain)
-                .disabled(isLatest)
-                .opacity(isLatest ? 0.5 : 1.0)
-                .onHover { hovering in
-                    isDeleteHovered = hovering && !isLatest
-                }
-            }
-            .padding(.leading, 8)
         }
+    }
+    
+    private func color(for tag: String) -> Color {
+        // Predefined colors to cycle through
+        let colors: [Color] = [
+            .red, .orange, .yellow, .green, .mint, .teal, .cyan, .blue, .indigo, .purple, .pink, .brown, .gray
+        ]
+        // Hash tag string and map to colors array index
+        let hash = tag.unicodeScalars.reduce(0, { $0 + UInt32($1.value) })
+        let colorIndex = Int(hash) % colors.count
+        return colors[colorIndex].opacity(0.3)
     }
 }
 
@@ -138,8 +161,8 @@ struct ClipboardItemRow: View {
         @State private var isSelected = false
         
         // Create sample items directly for preview
-        private let sampleItem1 = ClipboardItem(content: .text("This is a sample text item for preview"))
-        private let sampleItem2 = ClipboardItem(content: .text("This is another sample text item"))
+        private let sampleItem1 = ClipboardItem(content: .text("This is a sample text item for preview"), tag: ["Work", "Important"])
+        private let sampleItem2 = ClipboardItem(content: .text("This is another sample text item"), tag: ["Personal", "Urgent"])
         
         var body: some View {
             VStack(spacing: 20) {
@@ -150,7 +173,7 @@ struct ClipboardItemRow: View {
                     isSelected: isSelected,
                     onCopy: {}
                 )
-                .frame(height: 60)
+                .frame(height: 80)
                 
                 ClipboardItemRow(
                     item: sampleItem2,
@@ -159,7 +182,7 @@ struct ClipboardItemRow: View {
                     isSelected: !isSelected,
                     onCopy: {}
                 )
-                .frame(height: 60)
+                .frame(height: 80)
                 
                 Toggle("Toggle Selection", isOn: $isSelected)
                     .padding()
@@ -176,4 +199,17 @@ struct ClipboardItemRow: View {
     }
     
     return PreviewWrapper()
-} 
+}
+
+struct TagStyleModifier: ViewModifier {
+    var color: Color
+    func body(content: Content) -> some View {
+        content
+            .font(.caption2)
+            .padding(.vertical, 2)
+            .padding(.horizontal, 8)
+            .fontWeight(.regular)
+            .background(color)
+            .clipShape(Capsule())
+    }
+}

--- a/MacClipboard/Features/Clipboard/LandingLobby/Views/List/ClipboardItemTagger.swift
+++ b/MacClipboard/Features/Clipboard/LandingLobby/Views/List/ClipboardItemTagger.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+struct ClipboardItemTagger {
+    static func tags(for content: ClipboardContent) -> [String] {
+        var detectedTags = Set<String>()
+
+        switch content {
+        case .text(let string):
+            // Use NSDataDetector for specific types
+            if let detector = try? NSDataDetector(types:
+                NSTextCheckingResult.CheckingType.link.rawValue |
+                NSTextCheckingResult.CheckingType.phoneNumber.rawValue |
+                NSTextCheckingResult.CheckingType.date.rawValue |
+                NSTextCheckingResult.CheckingType.address.rawValue)
+            {
+                let matches = detector.matches(in: string, options: [], range: NSRange(location: 0, length: (string as NSString).length))
+                for match in matches {
+                    switch match.resultType {
+                    case .link: detectedTags.insert("Link")
+                    case .phoneNumber: detectedTags.insert("Number")
+                    case .date: detectedTags.insert("Date/Time")
+                    case .address: detectedTags.insert("Address")
+                    default: break
+                    }
+                }
+            }
+
+            // File path detection (improved with regex)
+            // Unix absolute path: starts with /
+            // Unix home-relative path: starts with ~/
+            // Unix dot-relative path: starts with ./
+            // Windows path: Drive letter followed by :\ or :/
+            let filePathPatterns = [
+                #"(?m)^(~\/|\.\/|\/)[^\0\s]*"#,              // Unix-style paths
+                #"(?m)^[a-zA-Z]:[\\/][^\0\s]*"#              // Windows-style paths
+            ]
+            for pattern in filePathPatterns {
+                if let _ = string.range(of: pattern, options: .regularExpression) {
+                    detectedTags.insert("File")
+                    break
+                }
+            }
+
+            // Code detection (look for common patterns)
+            let codeKeywords = ["func ", "class ", "struct ", "enum ", "import ", "public ", "private ", "{", "}"]
+            if codeKeywords.contains(where: { string.contains($0) }) {
+                detectedTags.insert("Code")
+            }
+
+            // Rich text detection (basic)
+            if string.contains("<html") || string.contains("<body") || string.contains("<div") || string.contains("style=") {
+                detectedTags.insert("Rich Text")
+            }
+            if string.contains("{\"ops\":") { // Quill.js or similar
+                detectedTags.insert("Rich Text")
+            }
+
+            // Numeric-only detection (could be an order ID, amount, etc.)
+            let numericString = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            if numericString.range(of: "^[0-9,.]+$", options: .regularExpression) != nil {
+                detectedTags.insert("Number")
+            }
+
+            // If no tags detected, fallback to plain text
+            if detectedTags.isEmpty {
+                detectedTags.insert("Text")
+            }
+
+        case .image(_):
+            detectedTags.insert("Image")
+        }
+
+        return Array(detectedTags)
+    }
+}

--- a/MacClipboard/Features/Clipboard/Models/ClipboardItem.swift
+++ b/MacClipboard/Features/Clipboard/Models/ClipboardItem.swift
@@ -5,28 +5,53 @@ struct ClipboardItem: Identifiable, Codable {
     let content: ClipboardContent
     let timestamp: Date
     var isFavorite: Bool
-    
-    init(id: UUID = UUID(), content: ClipboardContent, timestamp: Date = Date(), isFavorite: Bool = false) {
+    var tag: [String]  // Changed from String to [String]
+
+    init(id: UUID = UUID(), content: ClipboardContent, timestamp: Date = Date(), isFavorite: Bool = false, tag: [String] = []) {
         self.id = id
         self.content = content
         self.timestamp = timestamp
         self.isFavorite = isFavorite
+        self.tag = tag
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, content, timestamp, isFavorite, tag
+    }
+
+    // Custom encode/decode to handle [String] tag (array) properly
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        content = try container.decode(ClipboardContent.self, forKey: .content)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        isFavorite = try container.decode(Bool.self, forKey: .isFavorite)
+        tag = try container.decodeIfPresent([String].self, forKey: .tag) ?? []  // decode array, default empty array
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(content, forKey: .content)
+        try container.encode(timestamp, forKey: .timestamp)
+        try container.encode(isFavorite, forKey: .isFavorite)
+        try container.encode(tag, forKey: .tag)  // encode array of strings
     }
 }
 
 enum ClipboardContent: Codable {
     case text(String)
     case image(Data)
-    
+
     private enum CodingKeys: String, CodingKey {
         case type
         case value
     }
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let type = try container.decode(String.self, forKey: .type)
-        
+
         switch type {
         case "text":
             let value = try container.decode(String.self, forKey: .value)
@@ -38,10 +63,10 @@ enum ClipboardContent: Codable {
             throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Invalid type")
         }
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        
+
         switch self {
         case .text(let string):
             try container.encode("text", forKey: .type)

--- a/MacClipboard/Features/Clipboard/Models/ClipboardManager.swift
+++ b/MacClipboard/Features/Clipboard/Models/ClipboardManager.swift
@@ -74,7 +74,8 @@ class ClipboardManager: ObservableObject {
             }
         }
         
-        let newItem = ClipboardItem(content: content)
+        let tags = ClipboardItemTagger.tags(for: content)
+        let newItem = ClipboardItem(content: content, tag: tags)
         updateQueue.async { [weak self] in
             self?.updateItems(with: newItem, completion: completion)
         }


### PR DESCRIPTION
## Summary
- Introduces automatic tag detection and display for clipboard items.
- Adds keyboard navigation and shortcuts in the main list and group tabs.
- Refines UI across list rows and group tabs for consistency and usability.

## Changes by file
- MacClipboard/ContentView.swift
  - Switches `onChange(of: selectedTab)` signature to `(newValue, oldValue)`.
  - Adds Up/Down/Return key handling for list navigation and copy.
  - Adds Command+1…Command+9 and Command+0 tab switching logic.
  - Keeps selection in sync with `searchText`-filtered results.

- MacClipboard/Features/Clipboard/LandingLobby/Views/List/ClipboardGroupTabs.swift
  - Replaces plain buttons with `FixedHeightButtonStyle` (28pt) for consistency.
  - Displays per-group shortcut hints (⌘1…⌘9, ⌘0) and assigns actual shortcuts.
  - Adds hover feedback and dedicated hover state for delete affordance.
  - Layout/background tweaks and corner radius.
  - Adds `FixedHeightButtonStyle` helper.

- MacClipboard/Features/Clipboard/LandingLobby/Views/List/ClipboardItemRow.swift
  - Adds tag chips under content using `TagStyleModifier` with color hashing.
  - Adjusts row sizing (previews to 80) and hover states for action buttons.
  - Keeps context menu for group add/remove and favorites.
  - Selection highlight and spacing adjustments.

- MacClipboard/Features/Clipboard/LandingLobby/Views/List/ClipboardItemTagger.swift (new)
  - Detects tags from `ClipboardContent`:
    - Links, phone numbers, dates, addresses via `NSDataDetector`.
    - File paths (Unix and Windows patterns).
    - Code heuristics, rich text hints, numeric-only strings.
    - Images labeled as "Image".

- MacClipboard/Features/Clipboard/Models/ClipboardItem.swift
  - Adds `tag: [String]`.
  - Implements custom `Codable` to persist/read tag arrays (defaults to `[]`).

- MacClipboard/Features/Clipboard/Models/ClipboardManager.swift
  - Integrates `ClipboardItemTagger.tags(for:)` on item creation to auto-assign tags.

## Diff summary
- 6 files changed, 351 insertions, 167 deletions.
- 1 new file added: `ClipboardItemTagger.swift`.


## Notes
- Includes a warning removal commit and small cleanup.