### PR TITLE
Add Tag Filtering to Clipboard List with Multi-select Tag Bar

### DIFF
--- a/MacClipboard/Features/Clipboard/LandingLobby/Views/List/TagFilterBar.swift
+++ b/MacClipboard/Features/Clipboard/LandingLobby/Views/List/TagFilterBar.swift
@@ -34,8 +34,22 @@ struct TagFilterBar: View {
                         }
                     }) {
                         Text(tag)
-                            .modifier(TagStyleModifier(color: colorForTag(tag)))
+                            .font(.caption)
                             .fontWeight(selectedTags.contains(tag) ? .bold : .regular)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(
+                                selectedTags.contains(tag)
+                                    ? colorForTag(tag)
+                                    : Color.secondary.opacity(0.15)
+                            )
+                            .foregroundColor(selectedTags.contains(tag) ? .white : .primary)
+                            .cornerRadius(6)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .stroke(selectedTags.contains(tag) ? colorForTag(tag) : Color.clear, lineWidth: 1.5)
+                            )
+                            .shadow(color: selectedTags.contains(tag) ? colorForTag(tag).opacity(0.3) : .clear, radius: selectedTags.contains(tag) ? 3 : 0)
                     }
                     .buttonStyle(.plain)
                 }

--- a/MacClipboard/Features/Clipboard/LandingLobby/Views/List/TagFilterBar.swift
+++ b/MacClipboard/Features/Clipboard/LandingLobby/Views/List/TagFilterBar.swift
@@ -1,0 +1,46 @@
+//
+//  TagFilterBar.swift
+//  MacClipboard
+//
+//  Created by Hung-Chun Tsai on 2025-09-08.
+//
+import SwiftUI
+
+struct TagFilterBar: View {
+    let allTags: [String]
+    @Binding var selectedTags: Set<String>
+    let colorForTag: (String) -> Color
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                Button(action: { selectedTags.removeAll() }) {
+                    Text("All")
+                        .font(.caption)
+                        .fontWeight(selectedTags.isEmpty ? .bold : .regular)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(selectedTags.isEmpty ? Color.accentColor : Color.secondary.opacity(0.2))
+                        .foregroundColor(selectedTags.isEmpty ? .white : .primary)
+                        .cornerRadius(6)
+                }
+                .buttonStyle(.plain)
+                ForEach(allTags, id: \.self) { tag in
+                    Button(action: {
+                        if selectedTags.contains(tag) {
+                            selectedTags.remove(tag)
+                        } else {
+                            selectedTags.insert(tag)
+                        }
+                    }) {
+                        Text(tag)
+                            .modifier(TagStyleModifier(color: colorForTag(tag)))
+                            .fontWeight(selectedTags.contains(tag) ? .bold : .regular)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a horizontal tag filter bar to filter clipboard items by tag (multi-select).
- Updates list filtering to combine search text and selected tags.
- Improves tag chip visuals with stable color hashing per tag.

## Changes by file
- MacClipboard/Features/Clipboard/LandingLobby/Views/List/ClipboardListView.swift
  - Adds `selectedTags: Set<String>` state.
  - Adds `color(for:)` helper for stable tag colors.
  - Refactors `filteredItems` to apply search and tag filters together.
  - Adds `allTags` computed property for the tag bar.
  - Integrates new `TagFilterBar` above the list.
  - Updates preview to showcase multiple tags.

- MacClipboard/Features/Clipboard/LandingLobby/Views/List/TagFilterBar.swift (new)
  - New reusable tag filter component with multi-select buttons and "All" reset.
  - Selected tags highlighted with color, border, and subtle shadow.
  - No scroll indicators; compact horizontal layout.

## Diff summary
- 2 files changed, 130 insertions(+), 19 deletions(-)
- 1 new file added: `TagFilterBar.swift`.

## Commits included
- Enhance TagFilterBar UI for Improved Tag Selection
- Refactor ClipboardListView to Support Multiple Tag Selection
- Add Tag Filtering to ClipboardListView

## How to test
- Populate list with items having various tags (e.g., Work, Personal, Ideas).
- Toggle multiple tags in the tag bar; verify list shows items matching any selected tag.
- Combine tag filtering with search text; results should satisfy both.
- Click "All" to clear selection and show all items for the current tab.
- Verify no crashes or warnings during typical navigation.

## Notes
- Focused change set limited to tag filtering UX and related list filtering.
